### PR TITLE
Fixed "{{" and "}}" being removed from the documentation on the site

### DIFF
--- a/docs/chat-documentation.md
+++ b/docs/chat-documentation.md
@@ -3,6 +3,8 @@ title: Chat Documentation
 layout: markdown
 ---
 
+{% raw %}
+
 # OTB Project Documentation
 
 ### Interacting with a Bot in Chat
@@ -328,3 +330,5 @@ All commands are run by a user named “fred” and responded to by a bot named 
 |fred: !ifarg2|Bot: More args are needed. You need 2 args.|
 |fred: !ifarg2 one|Bot: More args are needed. You need 2 args.|
 |fred: !ifarg2 one two|Bot: More args are not needed. You needed 2 args.|
+
+{% endraw %}

--- a/docs/config-documentation.md
+++ b/docs/config-documentation.md
@@ -2,6 +2,9 @@
 title: Config Documentation
 layout: markdown
 ---
+
+{% raw %}
+
 # OTB Project Documentation
 
 ### Understanding and Modifying Configuration Files
@@ -190,3 +193,5 @@ The configuration file for a given channel can be found at:
 |`highPriorityLimit`|The number of messages queued to be sent in a channel after which messages of the priority 'High' will be dropped (they will not be queued).|
 |`defaultPriorityLimit`|The number of messages queued to be sent in a channel after which messages of the priority 'Default' will be dropped (they will not be queued).|
 |`lowPriorityLimit`|The number of messages queued to be sent in a channel after which messages of the priority 'Low' will be dropped (they will not be queued).|
+
+{% endraw %}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -2,6 +2,9 @@
 title: Tutorial
 layout: markdown
 ---
+
+{% raw %}
+
 # OTB Project Documentation
 
 ### Tutorial: How to Run a Bot
@@ -76,3 +79,5 @@ If you have any questions about the bot, feel free to leave them in the [issue t
 ### Other Notes
 
 This tutorial is geared towards users who are not familiar with terminals and might not be comfortable poking around config files on their own. The tutorial is not entirely accurate for users running the bot in a headless environment.
+
+{% endraw %}


### PR DESCRIPTION
Signed-off-by: Justin Wiblin <justin_wiblin@hotmail.co.uk>